### PR TITLE
Fixed: andymiller/pydtw#1

### DIFF
--- a/pydtw/dtw.py
+++ b/pydtw/dtw.py
@@ -72,8 +72,18 @@ def _trackeback(D):
         p.insert(0, i)
         q.insert(0, j)
 
-    p.insert(0, 0)
-    q.insert(0, 0)
+    # p.insert(0, 0)
+    # q.insert(0, 0)
+	if p[0] == 0:
+        while j > 0:
+            j -= 1
+            p.insert(0, i)
+            q.insert(0, j)
+    elif q[0] == 0:
+        while i > 0:
+            i -= 1
+            p.insert(0, i)
+            q.insert(0, j)
     return (np.array(p), np.array(q))
 
 


### PR DESCRIPTION
Maybe I found a bug in _function _trackeback(D)_ in _pydtw/dtw.py_. I think your function _trackeback(D) may ignore edge path of the cost matrix. In line 61 in _pydtw/dtw.py_, the code is `while(i > 0 and j > 0)`. When one of i or j is 0 and the other is not 0, the loop is end but do not reach the edge path of the cost matrix. For example, if I input two list, `[0,1,2] [0,0,0,1,2]`, the expected index mapping is `[0 0 0 1 2] [0 1 2 3 4]`, but the real index mapping is `[0 0 1 2] [0 2 3 4]`